### PR TITLE
Implement checkers move logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,28 +1,182 @@
 const boardElement = document.getElementById('board');
+const SIZE = 8;
+let board = [];
+let squares = [];
+let selected = null;
+let currentPlayer = 'white';
 
-function createBoard() {
-    for (let row = 0; row < 8; row++) {
-        for (let col = 0; col < 8; col++) {
+function initBoard() {
+    board = [];
+    squares = [];
+    boardElement.innerHTML = '';
+    for (let row = 0; row < SIZE; row++) {
+        board[row] = [];
+        squares[row] = [];
+        for (let col = 0; col < SIZE; col++) {
             const square = document.createElement('div');
             square.classList.add('square');
             if ((row + col) % 2 === 0) {
                 square.classList.add('light');
             } else {
                 square.classList.add('dark');
+            }
+            square.dataset.row = row;
+            square.dataset.col = col;
+            square.addEventListener('click', onSquareClick);
+            boardElement.appendChild(square);
+            squares[row][col] = square;
 
+            let piece = null;
+            if ((row + col) % 2 === 1) {
                 if (row < 3) {
-                    const piece = document.createElement('div');
-                    piece.classList.add('piece', 'black');
-                    square.appendChild(piece);
+                    piece = { color: 'black', king: false };
                 } else if (row > 4) {
-                    const piece = document.createElement('div');
-                    piece.classList.add('piece', 'white');
-                    square.appendChild(piece);
+                    piece = { color: 'white', king: false };
                 }
             }
-            boardElement.appendChild(square);
+            board[row][col] = piece;
+        }
+    }
+    renderBoard();
+}
+
+function renderBoard() {
+    for (let row = 0; row < SIZE; row++) {
+        for (let col = 0; col < SIZE; col++) {
+            const square = squares[row][col];
+            square.classList.remove('highlight');
+            square.innerHTML = '';
+            const piece = board[row][col];
+            if (piece) {
+                const p = document.createElement('div');
+                p.classList.add('piece', piece.color);
+                if (piece.king) p.classList.add('king');
+                square.appendChild(p);
+            }
         }
     }
 }
 
-document.addEventListener('DOMContentLoaded', createBoard);
+function withinBoard(row, col) {
+    return row >= 0 && row < SIZE && col >= 0 && col < SIZE;
+}
+
+function pieceHasCapture(row, col) {
+    const piece = board[row][col];
+    if (!piece) return false;
+    const dirs = piece.king
+        ? [[1,1],[1,-1],[-1,1],[-1,-1]]
+        : piece.color === 'white'
+            ? [[-1,1],[-1,-1]]
+            : [[1,1],[1,-1]];
+    for (const [dr, dc] of dirs) {
+        const r1 = row + dr;
+        const c1 = col + dc;
+        const r2 = row + dr * 2;
+        const c2 = col + dc * 2;
+        if (withinBoard(r2,c2) && board[r1][c1] && board[r1][c1].color !== piece.color && !board[r2][c2]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function hasAnyCapture(color) {
+    for (let r = 0; r < SIZE; r++) {
+        for (let c = 0; c < SIZE; c++) {
+            const p = board[r][c];
+            if (p && p.color === color && pieceHasCapture(r,c)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function getValidMoves(row, col, mustCapture) {
+    const piece = board[row][col];
+    if (!piece) return [];
+    const moves = [];
+    const dirs = piece.king
+        ? [[1,1],[1,-1],[-1,1],[-1,-1]]
+        : piece.color === 'white'
+            ? [[-1,1],[-1,-1]]
+            : [[1,1],[1,-1]];
+    for (const [dr, dc] of dirs) {
+        const r1 = row + dr;
+        const c1 = col + dc;
+        if (!withinBoard(r1,c1)) continue;
+        if (board[r1][c1] === null && !mustCapture) {
+            moves.push({row:r1,col:c1,capture:false});
+        } else if (board[r1][c1] && board[r1][c1].color !== piece.color) {
+            const r2 = r1 + dr;
+            const c2 = c1 + dc;
+            if (withinBoard(r2,c2) && board[r2][c2] === null) {
+                moves.push({row:r2,col:c2,capture:true,remove:{row:r1,col:c1}});
+            }
+        }
+    }
+    return moves;
+}
+
+function clearHighlights() {
+    for (let row = 0; row < SIZE; row++) {
+        for (let col = 0; col < SIZE; col++) {
+            squares[row][col].classList.remove('highlight');
+        }
+    }
+}
+
+function onSquareClick(e) {
+    const row = parseInt(this.dataset.row, 10);
+    const col = parseInt(this.dataset.col, 10);
+    const piece = board[row][col];
+    if (selected && selected.moves) {
+        const move = selected.moves.find(m => m.row === row && m.col === col);
+        if (move) {
+            executeMove(selected.row, selected.col, move);
+            return;
+        }
+    }
+
+    if (piece && piece.color === currentPlayer) {
+        const mustCap = hasAnyCapture(currentPlayer);
+        const moves = getValidMoves(row, col, mustCap);
+        selected = {row, col, moves};
+        clearHighlights();
+        for (const m of moves) {
+            squares[m.row][m.col].classList.add('highlight');
+        }
+    } else {
+        selected = null;
+        clearHighlights();
+    }
+}
+
+function executeMove(fromRow, fromCol, move) {
+    const piece = board[fromRow][fromCol];
+    board[move.row][move.col] = piece;
+    board[fromRow][fromCol] = null;
+    if (move.capture) {
+        board[move.remove.row][move.remove.col] = null;
+    }
+
+    if ((piece.color === 'white' && move.row === 0) || (piece.color === 'black' && move.row === SIZE-1)) {
+        piece.king = true;
+    }
+
+    renderBoard();
+
+    if (move.capture && pieceHasCapture(move.row, move.col)) {
+        selected = {row: move.row, col: move.col, moves: getValidMoves(move.row, move.col, true)};
+        for (const m of selected.moves) {
+            squares[m.row][m.col].classList.add('highlight');
+        }
+        return;
+    }
+
+    selected = null;
+    currentPlayer = currentPlayer === 'white' ? 'black' : 'white';
+}
+
+document.addEventListener('DOMContentLoaded', initBoard);

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,7 @@ body {
 .square {
     width: 60px;
     height: 60px;
+    position: relative;
 }
 
 .dark {
@@ -28,4 +29,30 @@ body {
 
 .light {
     background-color: #eeeed2;
+}
+
+.piece {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    cursor: pointer;
+}
+
+.piece.white {
+    background-color: #fff;
+    border: 2px solid #aaa;
+}
+
+.piece.black {
+    background-color: #000;
+    border: 2px solid #333;
+}
+
+.piece.king {
+    box-shadow: 0 0 0 3px gold inset;
+}
+
+.highlight {
+    outline: 3px solid yellow;
+    box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- add piece and highlight styles
- implement checker board state with movement logic
- support mandatory captures, multi-jumps, and king promotion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686bb430f7bc8331ba2181bdb0df9f77