### PR TITLE
Implement king promotion and movement

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -52,6 +52,20 @@ body {
     box-shadow: 0 0 0 3px gold inset;
 }
 
+.king {
+    background-color: gold;
+    border: 2px solid black;
+    position: relative;
+}
+
+.king::after {
+    content: "👑";
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    font-size: 18px;
+}
+
 .highlight {
     outline: 3px solid yellow;
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
- add `.king` style with golden background and crown icon
- store `isKing` flag for pieces
- add `promoteToKing` helper and update promotion logic
- update movement and evaluation logic to respect kings

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_b_686bb9fcef8883318df44b77786549d4